### PR TITLE
docs: Update README Endpoints section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This was built in 30 minutes, with tests included, using [Encore](https://encore
 
 ## Endpoints
 
-Create new diary entry:
+Listing all my entries for a specific date:
 
 ```bash
 curl -X GET "http://localhost:4000/logbook/entries/2022-09-08" | jq
@@ -27,7 +27,7 @@ curl -X GET "http://localhost:4000/logbook/entries/2022-09-08" | jq
 }
 ```
 
-Listing all my entries for a specific date:
+Create new diary entry:
 
 ```bash
 curl -X POST --data '{"Text":"I cooked fried eggs this morning. I forgot how much I loved them!"}' "http://localhost:4000/logbook/entries"


### PR DESCRIPTION
Swapped the descriptions of the two endpoints in the README Endpoints section. `Listing all my entries for a specific date:` goes with the `GET` method and  `Create new diary entry:` with the `POST` method. 

Fixes #2.

# Updated 

- [`ffe3201`](https://github.com/encoredev/example-app-diary/commit/ffe320161bf76805e2fd7703767dbbc40e6b00e5) fix: Update README Endpoints section